### PR TITLE
Revert Qodana linter version to 2024.2 in CI/CD configuration.

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -33,4 +33,4 @@ exclude:
 #  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)
 
 #Specify Qodana linter for analysis (Applied in CI/CD pipeline)
-linter: jetbrains/qodana-js:2024.3
+linter: jetbrains/qodana-js:2024.2


### PR DESCRIPTION
This pull request includes a small change to the `qodana.yaml` file. The change updates the version of the Qodana linter used for analysis in the CI/CD pipeline.

* [`qodana.yaml`](diffhunk://#diff-4e68a1f32b6f8d2d731d5d9a7aed51a3cbf67f2f15e68ac029f1ff7c2f87acabL36-R36): Updated the Qodana linter version from `jetbrains/qodana-js:2024.3` to `jetbrains/qodana-js:2024.2`.