### PR TITLE
Revert Qodana linter version to 2024.2 in CI/CD configuration.

### DIFF
--- a/.github/workflows/qodana-code-quality.yml
+++ b/.github/workflows/qodana-code-quality.yml
@@ -22,6 +22,3 @@ jobs:
         uses: JetBrains/qodana-action@v2024.2
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
-      - name: Run Qodana Scan
-        run: |
-          qodana scan --project-dir . --linter-version=2024.2

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -33,4 +33,4 @@ exclude:
 #  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)
 
 #Specify Qodana linter for analysis (Applied in CI/CD pipeline)
-linter: jetbrains/qodana-js:2024.3
+linter: jetbrains/qodana-js:2024.2


### PR DESCRIPTION
This pull request includes a minor update to the `qodana.yaml` file, specifically changing the version of the Qodana linter used for analysis in the CI/CD pipeline.

* [`qodana.yaml`](diffhunk://#diff-4e68a1f32b6f8d2d731d5d9a7aed51a3cbf67f2f15e68ac029f1ff7c2f87acabL36-R36): Updated the Qodana linter version from `2024.3` to `2024.2`.