### PR TITLE
Configuration updates, documentation corrections, contract modifications, and the addition of new unit tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,7 @@ ij_wrap_on_typing = false
 ij_solidity_keep_indents_on_empty_lines = false
 
 [.editorconfig]
+max_line_length = off
 ij_editorconfig_align_group_field_declarations = false
 ij_editorconfig_space_after_colon = false
 ij_editorconfig_space_after_comma = true
@@ -405,6 +406,7 @@ ij_json_spaces_within_brackets = false
 ij_json_wrap_long_lines = false
 
 [{*.markdown,*.md}]
+max_line_length = off
 ij_wrap_on_typing = true
 ij_markdown_force_one_space_after_blockquote_symbol = true
 ij_markdown_force_one_space_after_header_symbol = true

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ collateral, provided the loan is repaid within the same transaction.
 
 Key features of this system include:
 
-- **Price Arbitrage**: Capitalize on price misalignments between exchanges. Large trades can create imbalances in
+- **Price Arbitrage**: Capitalize on price misalignment's between exchanges. Large trades can create imbalances in
   liquidity pools, distorting prices and causing slippage.
 - **Smart Contract Relay**: Utilize a Solidity smart contract to act as a relay between the controller and the
   exchanges, ensuring efficient and secure transactions.

--- a/src/contracts/aflabContract.ts
+++ b/src/contracts/aflabContract.ts
@@ -165,7 +165,7 @@ class AflabContract extends BaseContract {
             data: this.contract.interface.encodeFunctionData(INITIATE_FLASHLOAN_SIG, [arbitrageInfo, inputAmount]),
             value: BigNumber.from(0),
             chainId: this.network,
-            gasLimit: 500000, // default gas limit
+            gasLimit: 1500000, // default gas limit
             gasPrice: await this.alchemy.core.getGasPrice(),
             nonce: await this.alchemy.core.getTransactionCount(from, "pending"),
         };

--- a/tests/unit/contracts/lendingPoolAPContract.test.ts
+++ b/tests/unit/contracts/lendingPoolAPContract.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LendingPoolAPContract } from "../../../src/contracts/lendingPoolAPContract.js";
+import { Alchemy, Contract } from "alchemy-sdk";
+import { Decimal } from "decimal.js";
+
+describe("LendingPoolAPContract", () => {
+    const mockAddress = "0x0000000000000000000000000000000000000000";
+    const mockAbi: object[] = [];
+    const mockNetwork = 1;
+
+    const mockCoreNamespace = {
+        call: vi.fn(),
+    };
+
+    const mockAlchemy = {
+        core: mockCoreNamespace,
+        config: {
+            getProvider: vi.fn(),
+        },
+    } as unknown as Alchemy;
+
+    let contract: LendingPoolAPContract;
+
+    beforeEach(() => {
+        contract = new LendingPoolAPContract(mockAddress, mockAlchemy, mockAbi, mockNetwork);
+    });
+
+    describe("getFlashloanFee", () => {
+        it("should return cached flashloan fee if available", async () => {
+            contract["flashloanFee"] = new Decimal(0.0009);
+            const fee = await contract.getFlashloanFee();
+            expect(fee.toString()).toBe("0.0009");
+            expect(mockCoreNamespace.call).not.toHaveBeenCalled();
+        });
+
+        it("should throw an error if poolContract is not defined", async () => {
+            await expect(contract.getFlashloanFee()).rejects.toThrow("Pool contract is not defined");
+        });
+
+        it("should call alchemy core to get flashloan fee", async () => {
+            const mockPoolContract = {
+                address: "0xMockPoolContract",
+                interface: {
+                    encodeFunctionData: vi.fn().mockReturnValue("mockData"),
+                },
+            };
+            contract["poolContract"] = mockPoolContract as unknown as Contract;
+
+            mockCoreNamespace.call.mockResolvedValue("9");
+
+            const fee = await contract.getFlashloanFee();
+
+            expect(fee.toString()).toBe("0.0009");
+            expect(mockCoreNamespace.call).toHaveBeenCalledTimes(1);
+            expect(mockCoreNamespace.call).toHaveBeenCalledWith({
+                to: "0xMockPoolContract",
+                data: "mockData",
+            });
+        });
+
+        it("should throw an error if call to alchemy core fails", async () => {
+            const mockPoolContract = {
+                address: "0xMockPoolContract",
+                interface: {
+                    encodeFunctionData: vi.fn().mockReturnValue("mockData"),
+                },
+            };
+            contract["poolContract"] = mockPoolContract as unknown as Contract;
+
+            mockCoreNamespace.call.mockRejectedValue(new Error("Network error"));
+
+            await expect(contract.getFlashloanFee()).rejects.toThrow("Failed to get flashloan fee");
+        });
+    });
+});

--- a/tests/unit/contracts/poolContract.test.ts
+++ b/tests/unit/contracts/poolContract.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PoolContract } from "../../../src/contracts/poolContract.js";
+import { Alchemy, BigNumber } from "alchemy-sdk";
+import { Decimal } from "decimal.js";
+import { UniswapV3Swap } from "../../../src/swaps/uniswapV3Swap.js";
+import { Pool } from "../../../src/types.js";
+
+class MockAlchemy extends Alchemy {}
+
+describe("PoolContract", () => {
+    const address = "0x123";
+    const abi: object[] = [];
+    const network = 1;
+    const pool: Pool = {
+        name: "Mock Pool",
+        symbol: "MP",
+        fees: [
+            { feePercentage: 1, feeType: "" },
+            { feePercentage: 2, feeType: "" },
+        ],
+        inputTokens: [
+            { id: "1", name: "Token1", symbol: "TK1", decimals: 18 },
+            { id: "2", name: "Token2", symbol: "TK2", decimals: 18 },
+        ],
+        id: "mock-pool-id",
+    };
+    const alchemy = new MockAlchemy();
+    const processSwap = vi.fn();
+    const lastPrice = BigNumber.from(1);
+
+    let poolContract: PoolContract;
+
+    beforeEach(() => {
+        poolContract = new PoolContract(address, alchemy, abi, pool, processSwap, network);
+        poolContract["lastPoolSqrtPriceX96"] = lastPrice;
+    });
+
+    it("should return the pool", () => {
+        expect(poolContract.getPool()).toBe(pool);
+    });
+
+    it("should throw an error if the pool is not defined", () => {
+        poolContract = new PoolContract(address, alchemy, abi, null as any, processSwap, network);
+        expect(() => poolContract.getPool()).toThrowError("Pool is not defined");
+    });
+
+    it("should return the last pool sqrt price X96", () => {
+        expect(poolContract.getLastPoolSqrtPriceX96()).toEqual(lastPrice);
+    });
+
+    it("should return the input tokens of the pool", () => {
+        expect(poolContract.getInputTokens()).toEqual(pool.inputTokens);
+    });
+
+    it("should throw an error if input tokens are not defined", () => {
+        pool.inputTokens = undefined as any;
+        expect(() => poolContract.getInputTokens()).toThrowError("Input tokens are not defined");
+    });
+
+    it("should return the total pool fees as a Decimal", () => {
+        const expectedFees = new Decimal(0.03);
+        expect(poolContract.getTotalPoolFeesAsDecimal()).toEqual(expectedFees);
+    });
+
+    it("should return the pool ID", () => {
+        expect(poolContract.getPoolId()).toBe("mock-pool-id");
+    });
+
+    it("should process a swap event correctly when swapEventCallback is called", async () => {
+        const mockArgs: [string, string, bigint, bigint, bigint, bigint, number] = [
+            "0xSender", // Sender
+            "0xRecipient", // Recipient
+            100n, // Amount0
+            200n, // Amount1
+            300n, // sqrtPriceX96
+            400n, // Liquidity
+            5, // Tick
+        ];
+
+        await poolContract["swapEventCallback"](...mockArgs);
+
+        expect(poolContract.getLastPoolSqrtPriceX96()).toEqual(BigNumber.from(300));
+
+        const swap = new UniswapV3Swap("0xSender", "0xRecipient", 100n, 200n, BigNumber.from(300), 400n, address);
+
+        expect(processSwap).toHaveBeenCalledWith(swap, lastPrice);
+    });
+});

--- a/tests/unit/subgraphs/baseSubgraph.test.ts
+++ b/tests/unit/subgraphs/baseSubgraph.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, Mock, vi } from "vitest";
+import { BaseSubgraph } from "../../../src/subgraphs/baseSubgraph.js";
+import { logger } from "../../../src/common.js";
+import { Client } from "@urql/core";
+
+class TestSubgraph extends BaseSubgraph {
+    protected customInit(): void {
+        // Minimal no-op custom init for testing
+    }
+}
+
+describe("BaseSubgraph", () => {
+    let subgraph: TestSubgraph;
+    let mockClient: Client;
+
+    beforeEach(() => {
+        // Mock logger
+        vi.spyOn(logger, "info").mockImplementation(() => {});
+        vi.spyOn(logger, "warn").mockImplementation(() => {});
+        vi.spyOn(logger, "error").mockImplementation(() => {});
+
+        // Mock client
+        mockClient = {
+            query: vi.fn().mockResolvedValue({ data: { mock: "result" } }),
+        } as any;
+
+        // Override the protected client for testing
+        // @ts-expect-error accessing protected property for test
+        subgraph = new TestSubgraph("http://mock-subgraph");
+        // @ts-expect-error accessing protected property for test
+        subgraph.client = mockClient;
+    });
+
+    it("should initialize and log without errors", () => {
+        subgraph.initialize();
+        expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Initialized subgraph"), "TestSubgraph");
+    });
+
+    it("should allow adding and retrieving queries", () => {
+        subgraph.addQuery("testQuery", "{ pools { id } }");
+        const query = subgraph.getQuery("testQuery");
+        expect(query).toBe("{ pools { id } }");
+    });
+
+    it("should throw an error when getting a non-existent query", () => {
+        expect(() => subgraph.getQuery("nonExistent")).toThrow("Query nonExistent not found");
+    });
+
+    it("should fetch data successfully", async () => {
+        // @ts-expect-error protected method access for test
+        const data = await subgraph.fetchData("{ pools { id } }");
+        expect(mockClient.query as Mock).toHaveBeenCalledWith("{ pools { id } }", undefined);
+        expect(data).toEqual({ mock: "result" });
+    });
+
+    it("should retry fetchData up to 3 times on failure", async () => {
+        (mockClient.query as Mock).mockRejectedValueOnce(new Error("Network Error"));
+        (mockClient.query as Mock).mockRejectedValueOnce(new Error("Network Error"));
+        (mockClient.query as Mock).mockResolvedValueOnce({ data: { retry: "success" } });
+
+        // @ts-expect-error protected method access for test
+        const data = await subgraph.fetchData("{ pools { id } }");
+        expect(mockClient.query as Mock).toHaveBeenCalledTimes(3);
+        expect(data).toEqual({ retry: "success" });
+    });
+
+    it("should throw an error after 3 failed fetchData attempts", async () => {
+        (mockClient.query as Mock).mockRejectedValue(new Error("Network Error"));
+
+        // @ts-expect-error protected method access for test
+        await expect(subgraph.fetchData("{ pools { id } }")).rejects.toThrow(
+            "Failed to fetch data, max retries exceeded",
+        );
+        expect(mockClient.query).toHaveBeenCalledTimes(3);
+    });
+});


### PR DESCRIPTION
This pull request includes various changes across multiple files, focusing on configuration updates, documentation corrections, contract modifications, and the addition of new unit tests. The most important changes include increasing the gas limit for a contract, adding unit tests for various contracts, and updating `.editorconfig` settings.

Configuration updates:

* [`.editorconfig`](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR21): Added `max_line_length = off` for general settings and markdown files. [[1]](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR21) [[2]](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR409)

Documentation corrections:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R24): Corrected a typo in the description of price arbitrage.

Contract modifications:

* [`src/contracts/aflabContract.ts`](diffhunk://#diff-331a062f8f3cf7981550272f9a1ea77e21b4b22eb1f6dcc84eb9dda01d038f8eL168-R168): Increased the gas limit from 500,000 to 1,500,000.

Unit tests additions:

* [`tests/unit/contracts/lendingPoolAPContract.test.ts`](diffhunk://#diff-a19b0299b93e3f723ef9a42cfa3b520dc3ef3ec52ed163b195f6362901afc5c7R1-R75): Added unit tests for the `LendingPoolAPContract` class, including tests for `getFlashloanFee` method.
* [`tests/unit/contracts/poolContract.test.ts`](diffhunk://#diff-9635e256e43c2156e44cfc8bda2ece00c7fccd95f3cb62d65d08c4a969f21f79R1-R88): Added unit tests for the `PoolContract` class, testing various methods like `getPool`, `getInputTokens`, and `swapEventCallback`.
* [`tests/unit/subgraphs/baseSubgraph.test.ts`](diffhunk://#diff-4047ddf574ca85c8391e0a28e47f69f79b2105ad8abe4dfbb06ff2665061af72R1-R76): Added unit tests for the `BaseSubgraph` class, covering initialization, query management, and data fetching with retries.